### PR TITLE
Simple change to get price by currency

### DIFF
--- a/src/services/CurrencyPricesService.php
+++ b/src/services/CurrencyPricesService.php
@@ -36,7 +36,7 @@ class CurrencyPricesService extends Component
     // Public Methods
 	// =========================================================================
 
-	public function getPricesByPurchasableId($id)
+	public function getPricesByPurchasableId($id, $currency = false)
 	{
 		$result = (new Query())
 			->select(['*'])
@@ -47,6 +47,10 @@ class CurrencyPricesService extends Component
 		if (!$result) {
 			return null;
 		}
+		
+		if ($currency) {
+            		return $result[$currency];
+        	}
 
 		return $result;
 	}


### PR DESCRIPTION
I've just added a simple change to extend the functionality of `getPricesByPurchasableId($id)` which allows you to get a single price instead of returning the full array.

I've tried to do it so it wont affect any existing implementations.

For example:
```
CurrencyPrices::$plugin->service->getPricesByPurchasableId($id, 'USD')
```

Would return the value of that currency for that particular purchasable.