### PR TITLE
Addons install fix

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -201,8 +201,8 @@ class Install extends Migration
 		$this->addForeignKey(null, '{{%commerce_shippingrules_currencyprices}}', ['paymentCurrencyIso'], '{{%commerce_paymentcurrencies}}', ['iso'], 'CASCADE');
 		$this->addForeignKey(null, '{{%commerce_discounts_currencyprices}}', ['discountId'], '{{%commerce_discounts}}', ['id'], 'CASCADE');
 		$this->addForeignKey(null, '{{%commerce_discounts_currencyprices}}', ['paymentCurrencyIso'], '{{%commerce_paymentcurrencies}}', ['iso'], 'CASCADE');
-		$this->addForeignKey(null, '{{%addons_discounts_currencyprices}}', ['discountId'], '{{%addons_discounts}}', ['id'], 'CASCADE');
-		$this->addForeignKey(null, '{{%addons_discounts_currencyprices}}', ['paymentCurrencyIso'], '{{%commerce_paymentcurrencies}}', ['iso'], 'CASCADE');
+		//$this->addForeignKey(null, '{{%addons_discounts_currencyprices}}', ['discountId'], '{{%addons_discounts}}', ['id'], 'CASCADE');
+		//$this->addForeignKey(null, '{{%addons_discounts_currencyprices}}', ['paymentCurrencyIso'], '{{%commerce_paymentcurrencies}}', ['iso'], 'CASCADE');
     }
 
     /**

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -201,8 +201,8 @@ class Install extends Migration
 		$this->addForeignKey(null, '{{%commerce_shippingrules_currencyprices}}', ['paymentCurrencyIso'], '{{%commerce_paymentcurrencies}}', ['iso'], 'CASCADE');
 		$this->addForeignKey(null, '{{%commerce_discounts_currencyprices}}', ['discountId'], '{{%commerce_discounts}}', ['id'], 'CASCADE');
 		$this->addForeignKey(null, '{{%commerce_discounts_currencyprices}}', ['paymentCurrencyIso'], '{{%commerce_paymentcurrencies}}', ['iso'], 'CASCADE');
-		//$this->addForeignKey(null, '{{%addons_discounts_currencyprices}}', ['discountId'], '{{%addons_discounts}}', ['id'], 'CASCADE');
-		//$this->addForeignKey(null, '{{%addons_discounts_currencyprices}}', ['paymentCurrencyIso'], '{{%commerce_paymentcurrencies}}', ['iso'], 'CASCADE');
+		$this->addForeignKey(null, '{{%addons_discounts_currencyprices}}', ['discountId'], '{{%commerce_discounts}}', ['id'], 'CASCADE');
+		$this->addForeignKey(null, '{{%addons_discounts_currencyprices}}', ['paymentCurrencyIso'], '{{%commerce_paymentcurrencies}}', ['iso'], 'CASCADE');
     }
 
     /**


### PR DESCRIPTION
A fresh install didn't work and saw the following error:

```
Exception: SQLSTATE[42P01]: Undefined table: 7 ERROR:  relation "addons_discounts" does not exist
The SQL being executed was: ALTER TABLE "addons_discounts_currencyprices" ADD CONSTRAINT "addons_discounts_currencyprices_discountId_fk" FOREIGN KEY ("discountId") REFERENCES "addons_discounts" ("id") ON DELETE CASCADE
```

This PR fixes that