### PR TITLE
Fixes error when saving shipping rules

### DIFF
--- a/src/assetbundles/currencyprices/dist/js/shipping.js
+++ b/src/assetbundles/currencyprices/dist/js/shipping.js
@@ -25,16 +25,16 @@
 						id: id,
 						name: name + 'CP',
 						label: $el
-							.parents('.field')
+							.closest('.field')
 							.find('label')
 							.text(),
 						instructions: $el
-							.parents('.field')
+							.closest('.field')
 							.find('.instructions')
 							.text()
 					},
 					function(response, status) {
-						$el.parents('.field').replaceWith($(response.html));
+						$el.closest('.field').replaceWith($(response.html));
 
 						loaded++;
 						if (loaded == found) {


### PR DESCRIPTION
This small commit fixes https://github.com/KuriousAgency/commerce-currency-prices/issues/19. 

`parents('.field')` wasn't specific enough so it was replacing multiple fields (min/max totals) and then when those fields were missing on submit, it threw an error. `closest('.field')` only replaces the nearest parent and fixes this issue.